### PR TITLE
Remove a dependency that can be addressed in the upstream than tensorflow_ros_cpp

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,4 +16,5 @@
   <build_depend>python-pip</build_depend> <!-- optional -->
 
   <depend>python-tensorflow-pip</depend> <!-- optional -->
+  <depend>tensorflow_catkin</depend> <!-- optional -->
 </package>

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <build_export_depend>python</build_export_depend>
 
   <build_depend>python-pip</build_depend> <!-- optional -->
-  <build_depend>swig</build_depend>
 
   <depend>python-tensorflow-pip</depend> <!-- optional -->
 </package>

--- a/package.xml
+++ b/package.xml
@@ -17,5 +17,4 @@
   <build_depend>swig</build_depend>
 
   <depend>python-tensorflow-pip</depend> <!-- optional -->
-  <depend>tensorflow_catkin</depend> <!-- optional -->
 </package>


### PR DESCRIPTION
Re-opening https://github.com/tradr-project/tensorflow_ros/pull/9 to the right repo.